### PR TITLE
Add new categories to 'All Ores'

### DIFF
--- a/il/ores.md
+++ b/il/ores.md
@@ -7,12 +7,13 @@
 
 * Must obtain all ores corresponding to your subcategory.
 	- Ingots count as ores.
+	- Iron nuggets, gold nuggets, and netherite scrap do not count as ores.
 * All ores must be in your inventory at the end of the run.
 * Timing ends the frame the last ore enters the inventory.
 	- See the [timing rules](../global/README.md#timing-rules) regarding
 	when timing begins.
 
-## Pre-1.16
+## All Ores: Pre 1.16
 
 * Must collect the following ores:
 	- Coal
@@ -24,7 +25,7 @@
 	- Emerald
 	- Nether Quartz
 
-## 1.16+
+## All Ores: 1.16+
 
 * Must collect the following ores:
 	- Coal
@@ -37,7 +38,21 @@
 	- Nether Quartz
 	- Ancient Debris
 
-## All Overworld Ores
+## All Ores: 1.17+
+
+* Must collect the following ores:
+	- Coal
+	- Copper
+	- Iron
+	- Gold
+	- Lapis Lazuli
+	- Redstone
+	- Diamond
+	- Emerald
+	- Nether Quartz
+	- Ancient Debris
+
+## All Overworld Ores: Pre 1.16
 
 * Must collect the following ores:
 	- Coal
@@ -48,10 +63,33 @@
 	- Diamond
 	- Emerald
 
-## All Overworld Ores - No Emerald
+## All Overworld Ores - No Emerald: Pre 1.16
 
 * Must collect the following ores:
 	- Coal
+	- Iron
+	- Gold
+	- Lapis Lazuli
+	- Redstone
+	- Diamond
+
+## All Overworld Ores: 1.17+
+
+* Must collect the following ores:
+	- Coal
+	- Copper
+	- Iron
+	- Gold
+	- Lapis Lazuli
+	- Redstone
+	- Diamond
+	- Emerald
+
+## All Overworld Ores - No Emerald: 1.17+
+
+* Must collect the following ores:
+	- Coal
+	- Copper
 	- Iron
 	- Gold
 	- Lapis Lazuli


### PR DESCRIPTION
The rules are updated to include the new category-specific ores. "Iron nuggets, gold nuggets, and netherite scrap do not count as ores" is also clarified - it has already been generally accepted by moderators and runners.