### PR TITLE
global: ban twitch, discord, and the obvious sites

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -90,6 +90,11 @@ world seed for every submission, but it is not mandatory
 	- A run may be rejected if there are too many dropped frames, as it
 	makes accurate retiming impossible.
 	- Audio is not required.
+	- The following websites are banned and cannot be used for video
+	submission:
+		+ twitch.tv
+		+ discord.com
+		+ All websites centered around NSFW content
 * It is not required to have a timer.
 * Editing the video in any way, shape, or form that affects the resulting time
 of the run is strictly against the rules.


### PR DESCRIPTION
Twitch has announced it will be deleting highlights from users. This is especially troubling for speedrunners who often use twitch to store large amounts of runs. As such it should not be relied on as a source for video evidence.
This is not even the first time it has happened[2], so best to just cut it out now.

Discord has already been banned, but never written down it seems, so time to write it down now. It was never a major source of speedruns in Minecraft Bedrock, but regardless recent changes[3] have made it an unviable platform for video submissions.

Lastly, NSFW sites have always been banned, both in Minecraft Bedrock and site wide. Regardless, someone will come up after a rule change and try to test it. Best to address it now.

[1]: https://www.pcmag.com/news/twitch-caps-users-uploads-and-highlights-at-100-hours
[2]: https://wiki.archiveteam.org/index.php/Twitch.tv
[3]: https://www.ghacks.net/2023/11/06/discord-makes-file-links-temporary-to-fight-abuse/