### PR TITLE
catext/beta: point to glitchless rules

### DIFF
--- a/catext/beta-coop.md
+++ b/catext/beta-coop.md
@@ -5,9 +5,5 @@
 
 [Back](../README.md)
 
-This leaderboard was originally created to store runs for 1.16 betas that had
-seeds broken after updates. There are also some features that arguably make
-speedrunning 1.16 beta rsg easier/faster.
-
 * All [1.16 Beta Solo rules](./beta.md) apply to this category.
 * All [cooperative specific rules](../coop/README.md) apply to this category.

--- a/catext/beta.md
+++ b/catext/beta.md
@@ -5,11 +5,7 @@
 
 [Back](../README.md)
 
-This leaderboard was originally created to store runs for 1.16 betas that had
-seeds broken after updates. There are also some features that arguably make
-speedrunning 1.16 beta rsg easier/faster.
-
-* All [Any% rules](../fullgame/any.md) apply to this category.
+* All [Any% rules](../fullgame/any-glitchless.md) apply to this category.
 * You must play on a beta version of 1.16
 * Seeds that are used on the main boards and work on both beta and full-release
 are not allowed.


### PR DESCRIPTION
The beta 1.16 categories are glitchless, as such the rules should point
to the glitchless section.

Removing the reasoning for the beta category, as that is better fitted
in a commit message or a documentation page rather than the rules
themselves.
